### PR TITLE
Fix: Resolve psycopg2 import error and ensure MySQL compatibility

### DIFF
--- a/scraapy/settings.py
+++ b/scraapy/settings.py
@@ -71,7 +71,6 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'django.contrib.postgres',
     'rest_framework',
     'knox',
     'sms',


### PR DESCRIPTION
The application was configured to use MySQL in settings.py but included 'django.contrib.postgres' in INSTALLED_APPS. This caused an ImportError for 'psycopg2' when running the server, as Django attempted to load PostgreSQL-specific components.

This commit removes 'django.contrib.postgres' from INSTALLED_APPS to prevent the import error and align the application's installed components with its MySQL database configuration.

During troubleshooting, I also ensured system dependencies for mysqlclient were in place, and the MySQL database and user were configured as per your settings.